### PR TITLE
🐛harden metadata failure handling

### DIFF
--- a/src/scripts/extensions/api.ts
+++ b/src/scripts/extensions/api.ts
@@ -1,4 +1,4 @@
-export type ResponseState = 'ok' | 'network-error' | 'server-error';
+export type ResponseState = 'ok' | 'network-error' | 'server-error' | 'invalid-json';
 export type ApiSuccessResponse<T> = {
     status: 'ok';
     data: T;
@@ -6,6 +6,7 @@ export type ApiSuccessResponse<T> = {
 
 export type ApiErrorResponse = {
     status: Exclude<ResponseState, 'ok'>;
+    httpStatus?: number;
 };
 
 export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
@@ -24,14 +25,14 @@ class Api {
         }
 
         if (!response.ok) {
-            return { status: 'server-error' };
+            return { status: 'server-error', httpStatus: response.status };
         }
 
         try {
             const data = (await response.json()) as T;
             return { status: 'ok', data };
         } catch {
-            return { status: 'server-error' };
+            return { status: 'invalid-json', httpStatus: response.status };
         }
     }
 

--- a/src/scripts/platform/android.ts
+++ b/src/scripts/platform/android.ts
@@ -6,6 +6,7 @@ class AndroidModule extends PlatformModule {
     protected async attach(): Promise<void> {
         const meta = await fetchMeta();
         if (!meta.ok) {
+            console.warn(`[platform:android] Skip version update UI because ${meta.reason}`);
             return;
         }
 
@@ -36,6 +37,11 @@ class AndroidModule extends PlatformModule {
     }
 
     private updateDownloadLink(versionMeta: VersionMeta): void {
+        if (!versionMeta.android) {
+            console.warn('[platform:android] Missing Android download URL in version metadata');
+            return;
+        }
+
         document.getElementById('android-download-update')!.onclick = () => {
             window.open(versionMeta.android, '_blank');
         };

--- a/src/scripts/platform/base.ts
+++ b/src/scripts/platform/base.ts
@@ -1,11 +1,16 @@
 import Api from '~/extensions/api';
 import bus from '~/extensions/event';
 import { AppMeta, VersionMeta, parseAppMeta, parseVersionMeta } from '~/models';
+import { ApiErrorResponse } from '~/extensions/api';
 
 export type MetaFailureReason =
-    | 'app-meta-fetch-failed'
+    | 'app-meta-network-error'
+    | 'app-meta-server-error'
+    | 'app-meta-invalid-json'
     | 'app-meta-invalid'
-    | 'version-meta-fetch-failed'
+    | 'version-meta-network-error'
+    | 'version-meta-server-error'
+    | 'version-meta-invalid-json'
     | 'version-meta-invalid';
 
 export type MetaResponse =
@@ -17,30 +22,62 @@ export type MetaResponse =
     | {
           ok: false;
           reason: MetaFailureReason;
+          httpStatus?: number;
       };
+
+function mapFailureReason(prefix: 'app-meta' | 'version-meta', response: ApiErrorResponse): MetaFailureReason {
+    if (response.status === 'network-error') {
+        return `${prefix}-network-error`;
+    }
+    if (response.status === 'invalid-json') {
+        return `${prefix}-invalid-json`;
+    }
+    return `${prefix}-server-error`;
+}
+
+function logMetaFailure(meta: Extract<MetaResponse, { ok: false }>): void {
+    if (meta.httpStatus !== undefined) {
+        console.error(`[meta] ${meta.reason} (http ${meta.httpStatus})`);
+    } else {
+        console.error(`[meta] ${meta.reason}`);
+    }
+}
 
 export async function fetchMeta(): Promise<MetaResponse> {
     const appMetaResponse = await Api.fetch<unknown>('meta.json');
     if (appMetaResponse.status !== 'ok') {
-        console.error('Failed to fetch App meta');
-        return { ok: false, reason: 'app-meta-fetch-failed' };
+        const failed: Extract<MetaResponse, { ok: false }> = {
+            ok: false,
+            reason: mapFailureReason('app-meta', appMetaResponse),
+            httpStatus: appMetaResponse.httpStatus,
+        };
+        logMetaFailure(failed);
+        return failed;
     }
+
     const appMeta = parseAppMeta(appMetaResponse.data);
     if (!appMeta) {
-        console.error('Invalid App meta payload');
-        return { ok: false, reason: 'app-meta-invalid' };
+        const failed: Extract<MetaResponse, { ok: false }> = { ok: false, reason: 'app-meta-invalid' };
+        logMetaFailure(failed);
+        return failed;
     }
 
     const versionMetaResponse = await Api.fetch<unknown>(`${appMeta.latest}/meta.json`);
     if (versionMetaResponse.status !== 'ok') {
-        console.error('Failed to fetch Version meta');
-        return { ok: false, reason: 'version-meta-fetch-failed' };
+        const failed: Extract<MetaResponse, { ok: false }> = {
+            ok: false,
+            reason: mapFailureReason('version-meta', versionMetaResponse),
+            httpStatus: versionMetaResponse.httpStatus,
+        };
+        logMetaFailure(failed);
+        return failed;
     }
 
     const versionMeta = parseVersionMeta(versionMetaResponse.data);
     if (!versionMeta) {
-        console.error('Invalid Version meta payload');
-        return { ok: false, reason: 'version-meta-invalid' };
+        const failed: Extract<MetaResponse, { ok: false }> = { ok: false, reason: 'version-meta-invalid' };
+        logMetaFailure(failed);
+        return failed;
     }
 
     return { ok: true, appMeta, versionMeta };

--- a/src/scripts/platform/web.ts
+++ b/src/scripts/platform/web.ts
@@ -6,6 +6,7 @@ class WebModule extends PlatformModule {
     protected async attach(): Promise<void> {
         const meta = await fetchMeta();
         if (!meta.ok) {
+            console.warn(`[platform:web] Skip version update UI because ${meta.reason}`);
             return;
         }
 
@@ -23,6 +24,11 @@ class WebModule extends PlatformModule {
     }
 
     private updateDownloadLink(versionMeta: VersionMeta): void {
+        if (!versionMeta.android) {
+            console.warn('[platform:web] Missing Android download URL in version metadata');
+            return;
+        }
+
         document.getElementById('web-download-android')!.onclick = () => {
             window.open(versionMeta.android, '_blank');
         };


### PR DESCRIPTION
- classify API failures with invalid-json/http status context
- map metadata failures to explicit app/version failure reasons
- guard web/android update links when metadata is incomplete