### PR TITLE
Fix playback desync with beats display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,21 +11,21 @@
             "dependencies": {
                 "@aashu-dubey/capacitor-statusbar-safe-area": "^4.0.0",
                 "@capacitor-community/keep-awake": "^8.0.1",
-                "@capacitor/android": "^8.3.1",
-                "@capacitor/core": "^8.3.1",
-                "@capacitor/ios": "^8.3.1",
+                "@capacitor/android": "^8.3.4",
+                "@capacitor/core": "^8.3.4",
+                "@capacitor/ios": "^8.3.4",
                 "capacitor-metronome-background": "file:plugins/capacitor-metronome-background",
                 "mitt": "^3.0.1"
             },
             "devDependencies": {
                 "@capacitor/assets": "^3.0.5",
-                "@capacitor/cli": "^8.3.1",
+                "@capacitor/cli": "^8.3.4",
                 "jsdom": "^29.1.1",
                 "prettier": "^3.8.3",
                 "typescript": "^6.0.3",
-                "vite": "^8.0.10",
+                "vite": "^8.0.14",
                 "vite-plugin-html-minifier": "^1.0.5",
-                "vitest": "^4.1.5"
+                "vitest": "^4.1.7"
             }
         },
         "node_modules/@aashu-dubey/capacitor-statusbar-safe-area": {
@@ -136,9 +136,9 @@
             }
         },
         "node_modules/@capacitor/android": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.1.tgz",
-            "integrity": "sha512-hjskIG8YcBEh3X4yaTXvE9gcqpdcxunTgFruSKnuPxtMxAUzEK4Oq25x0Z1g3cz+MQPc+lRG09R7Ovc+ydKsNw==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.4.tgz",
+            "integrity": "sha512-7gJjrG3X32Am1QMLqgMztWTYMLMVNE+VZwhekNxhvYizH4mOV05vH+rC9B+f17bCkYZfyu/qXQX6hoY7kLeVZw==",
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": "^8.3.0"
@@ -467,9 +467,9 @@
             }
         },
         "node_modules/@capacitor/cli": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.1.tgz",
-            "integrity": "sha512-1sPGW4THTDfR6YjXwZ0jM7oAfAtciPOHN00qs/3sNAQx1kKrrEYSfDPwCm1/xlAgi0OeL69SiRfw314Ans+1sw==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.4.tgz",
+            "integrity": "sha512-QEmyNdiDDVNYl0Mahm7YTVA/3t2tKcy7FWYDapeKGavS6HDNHZSjyTVwQpUXQbDZrrs/PS2Wau3Aii+LIFwm/A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -550,18 +550,18 @@
             }
         },
         "node_modules/@capacitor/core": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.1.tgz",
-            "integrity": "sha512-UF8ItlHguU1Z6GXfPTeT2gakf+ctNI8pAS1kwSBQlsJMlfD4OPoto/SmKnOxKCQvnF4WRcdWeg6C0zREUNaAQg==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.4.tgz",
+            "integrity": "sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/@capacitor/ios": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.1.tgz",
-            "integrity": "sha512-BEhLyYYHWJLib4mpaPMaaylbC8meqgxbNYwQJH2svsSLW7yo/hFie+Zoo66a44XnqcMd2tvmAuzimWunXZi/xA==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.4.tgz",
+            "integrity": "sha512-XvvnPFWWP/gwwO811ue7nEBKSZqDCIB8hxGgWV6iXA7DSVLqMOEmQdfHj94kkVxof2wL9XWHypu3ayDULo7U5w==",
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": "^8.3.0"
@@ -1044,75 +1044,14 @@
                 "@emnapi/runtime": "^1.7.1"
             }
         },
-        "node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/@oxc-project/types": {
-            "version": "0.127.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+            "version": "0.132.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+            "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/@paralleldrive/cuid2": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
-            "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "^1.1.5"
             }
         },
         "node_modules/@prettier/plugin-xml": {
@@ -1127,9 +1066,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+            "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1144,9 +1083,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+            "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
             "cpu": [
                 "arm64"
             ],
@@ -1161,9 +1100,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+            "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
             "cpu": [
                 "x64"
             ],
@@ -1178,9 +1117,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+            "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
             "cpu": [
                 "x64"
             ],
@@ -1195,9 +1134,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+            "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
             "cpu": [
                 "arm"
             ],
@@ -1212,9 +1151,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+            "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
             "cpu": [
                 "arm64"
             ],
@@ -1229,9 +1168,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+            "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
             ],
@@ -1246,9 +1185,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+            "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1263,9 +1202,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+            "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1280,9 +1219,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+            "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
             "cpu": [
                 "x64"
             ],
@@ -1297,9 +1236,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+            "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
             ],
@@ -1314,9 +1253,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+            "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
             "cpu": [
                 "arm64"
             ],
@@ -1331,9 +1270,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+            "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -1350,9 +1289,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+            "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1367,9 +1306,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+            "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
             "cpu": [
                 "x64"
             ],
@@ -1384,9 +1323,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1405,9 +1344,9 @@
             "license": "SEE LICENSE"
         },
         "node_modules/@trapezedev/project": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@trapezedev/project/-/project-7.1.3.tgz",
-            "integrity": "sha512-GANh8Ey73MechZrryfJoILY9hBnWqzS6AdB53zuWBCBbaiImyblXT41fWdN6pB2f5+cNI2FAUxGfVhl+LeEVbQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@trapezedev/project/-/project-7.1.4.tgz",
+            "integrity": "sha512-b5rszBgT5XiRp/m4V2S2Ara2fdFXhPiduxhvCIVTSHq51PgLBjiTEStL6NbUz3V0K5bebF971O+SLRtyBxfCNA==",
             "dev": true,
             "license": "SEE LICENSE",
             "dependencies": {
@@ -1415,7 +1354,7 @@
                 "@ionic/utils-subprocess": "^2.1.8",
                 "@prettier/plugin-xml": "^2.2.0",
                 "@trapezedev/gradle-parse": "7.1.3",
-                "@xmldom/xmldom": "^0.7.5",
+                "@xmldom/xmldom": "^0.9.9",
                 "conventional-changelog": "^3.1.4",
                 "cross-spawn": "^7.0.3",
                 "diff": "^5.1.0",
@@ -1424,12 +1363,11 @@
                 "ini": "^2.0.0",
                 "kleur": "^4.1.5",
                 "lodash": "^4.17.21",
-                "mergexml": "^1.2.3",
                 "plist": "^3.0.4",
                 "prettier": "^2.7.1",
                 "prompts": "^2.4.2",
                 "replace": "^1.1.0",
-                "tempy": "^1.0.1",
+                "tempy": "^3.1.0",
                 "tmp": "^0.2.1",
                 "ts-node": "^10.2.1",
                 "xcode": "^3.0.1",
@@ -1512,14 +1450,13 @@
             }
         },
         "node_modules/@trapezedev/project/node_modules/@xmldom/xmldom": {
-            "version": "0.7.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-            "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-            "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.6"
             }
         },
         "node_modules/@trapezedev/project/node_modules/env-paths": {
@@ -1590,9 +1527,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1619,9 +1556,9 @@
             "license": "MIT"
         },
         "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1667,16 +1604,16 @@
             "license": "MIT"
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+            "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1685,13 +1622,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+            "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.5",
+                "@vitest/spy": "4.1.7",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1712,9 +1649,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+            "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1725,13 +1662,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+            "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.5",
+                "@vitest/utils": "4.1.7",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1739,14 +1676,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+            "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1755,9 +1692,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+            "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1765,13 +1702,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+            "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
+                "@vitest/pretty-format": "4.1.7",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1832,20 +1769,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1886,16 +1809,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1905,13 +1818,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
@@ -2119,19 +2025,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2303,16 +2196,6 @@
             },
             "engines": {
                 "node": ">= 10.0"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/cliui": {
@@ -2699,13 +2582,32 @@
             }
         },
         "node_modules/crypto-random-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "type-fest": "^1.0.1"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/crypto-random-string/node_modules/type-fest": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/css-select": {
@@ -2922,92 +2824,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/del": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-            "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "globby": "^11.0.1",
-                "graceful-fs": "^4.2.4",
-                "is-glob": "^4.0.1",
-                "is-path-cwd": "^2.2.0",
-                "is-path-inside": "^3.0.2",
-                "p-map": "^4.0.0",
-                "rimraf": "^3.0.2",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/del/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/del/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/del/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/del/node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3018,17 +2834,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/dezalgo": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-            }
-        },
         "node_modules/diff": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -3037,29 +2842,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/dir-glob/node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/dom-serializer": {
@@ -3269,33 +3051,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fastq": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-            "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3304,19 +3059,6 @@
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -3360,24 +3102,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/formidable": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
-            "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@paralleldrive/cuid2": "^2.2.2",
-                "dezalgo": "^1.0.4",
-                "once": "^1.4.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "url": "https://ko-fi.com/tunnckoCore/commissions"
             }
         },
         "node_modules/fs-constants": {
@@ -3684,40 +3408,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3908,16 +3598,6 @@
             ],
             "license": "BSD-3-Clause"
         },
-        "node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3926,18 +3606,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
             }
         },
         "node_modules/inherits": {
@@ -3996,16 +3664,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4016,53 +3674,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/is-obj": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
             "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-path-cwd": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4087,13 +3702,13 @@
             "license": "MIT"
         },
         "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4913,63 +4528,6 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/mergexml": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/mergexml/-/mergexml-1.2.4.tgz",
-            "integrity": "sha512-yiOlDqcVCz7AG1eSboonc18FTlfqDEKYfGoAV3Lul98u6YRV/s0kjtf4bjk47t0hLTFJR0BSYMd6BpmX3xDjNQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@xmldom/xmldom": "^0.7.0",
-                "formidable": "^3.5.1",
-                "xpath": "0.0.27"
-            }
-        },
-        "node_modules/mergexml/node_modules/@xmldom/xmldom": {
-            "version": "0.7.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-            "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-            "deprecated": "this version is no longer supported, please update to at least 0.8.*",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/mergexml/node_modules/xpath": {
-            "version": "0.0.27",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-            "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/mimic-response": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -5020,9 +4578,9 @@
             }
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5353,22 +4911,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -5458,16 +5000,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5546,19 +5078,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -5585,9 +5104,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.13",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -5605,7 +5124,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -5756,27 +5275,6 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/quick-lru": {
             "version": "4.0.1",
@@ -6154,17 +5652,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rimraf": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
@@ -6186,14 +5673,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+            "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.127.0",
-                "@rolldown/pluginutils": "1.0.0-rc.17"
+                "@oxc-project/types": "=0.132.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -6202,45 +5689,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
+                "@rolldown/binding-android-arm64": "1.0.2",
+                "@rolldown/binding-darwin-arm64": "1.0.2",
+                "@rolldown/binding-darwin-x64": "1.0.2",
+                "@rolldown/binding-freebsd-x64": "1.0.2",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+                "@rolldown/binding-linux-arm64-musl": "1.0.2",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-musl": "1.0.2",
+                "@rolldown/binding-openharmony-arm64": "1.0.2",
+                "@rolldown/binding-wasm32-wasi": "1.0.2",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+                "@rolldown/binding-win32-x64-msvc": "1.0.2"
             }
         },
         "node_modules/safe-buffer": {
@@ -6460,16 +5923,6 @@
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
@@ -6777,43 +6230,42 @@
             }
         },
         "node_modules/temp-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=14.16"
             }
         },
         "node_modules/tempy": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-            "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+            "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "del": "^6.0.0",
-                "is-stream": "^2.0.0",
-                "temp-dir": "^2.0.0",
-                "type-fest": "^0.16.0",
-                "unique-string": "^2.0.0"
+                "is-stream": "^3.0.0",
+                "temp-dir": "^3.0.0",
+                "type-fest": "^2.12.2",
+                "unique-string": "^3.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tempy/node_modules/type-fest": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-            "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
-                "node": ">=10"
+                "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6985,19 +6437,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
             }
         },
         "node_modules/tough-cookie": {
@@ -7172,16 +6611,19 @@
             "license": "MIT"
         },
         "node_modules/unique-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "crypto-random-string": "^2.0.0"
+                "crypto-random-string": "^4.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/universalify": {
@@ -7240,16 +6682,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.10",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+            "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.17",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.2",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -7266,7 +6708,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
+                "@vitejs/devtools": "^0.1.18",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -7348,19 +6790,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+            "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.5",
-                "@vitest/mocker": "4.1.5",
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/runner": "4.1.5",
-                "@vitest/snapshot": "4.1.5",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/expect": "4.1.7",
+                "@vitest/mocker": "4.1.7",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/runner": "4.1.7",
+                "@vitest/snapshot": "4.1.7",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -7388,12 +6830,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.5",
-                "@vitest/browser-preview": "4.1.5",
-                "@vitest/browser-webdriverio": "4.1.5",
-                "@vitest/coverage-istanbul": "4.1.5",
-                "@vitest/coverage-v8": "4.1.5",
-                "@vitest/ui": "4.1.5",
+                "@vitest/browser-playwright": "4.1.7",
+                "@vitest/browser-preview": "4.1.7",
+                "@vitest/browser-webdriverio": "4.1.7",
+                "@vitest/coverage-istanbul": "4.1.7",
+                "@vitest/coverage-v8": "4.1.7",
+                "@vitest/ui": "4.1.7",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -22,21 +22,21 @@
     "dependencies": {
         "@aashu-dubey/capacitor-statusbar-safe-area": "^4.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",
-        "@capacitor/android": "^8.3.1",
-        "@capacitor/core": "^8.3.1",
-        "@capacitor/ios": "^8.3.1",
+        "@capacitor/android": "^8.3.4",
+        "@capacitor/core": "^8.3.4",
+        "@capacitor/ios": "^8.3.4",
         "capacitor-metronome-background": "file:plugins/capacitor-metronome-background",
         "mitt": "^3.0.1"
     },
     "devDependencies": {
         "@capacitor/assets": "^3.0.5",
-        "@capacitor/cli": "^8.3.1",
+        "@capacitor/cli": "^8.3.4",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
-        "vite": "^8.0.10",
+        "vite": "^8.0.14",
         "vite-plugin-html-minifier": "^1.0.5",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.7"
     },
     "author": "Tony S.",
     "license": "MIT",

--- a/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
+++ b/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
@@ -12,7 +12,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
-@CapacitorPlugin(name = "MetronomeBackground")
+@CapacitorPlugin(name = "MetronomeBackground", events = { "beat" })
 public class MetronomeBackgroundPlugin extends Plugin {
 
     @Override

--- a/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
+++ b/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
@@ -12,23 +12,51 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
-@CapacitorPlugin(name = "MetronomeBackground", events = { "beat" })
+@CapacitorPlugin(name = "MetronomeBackground")
 public class MetronomeBackgroundPlugin extends Plugin {
+
+    private PluginCall savedBeatCall;
 
     @Override
     public void load() {
         super.load();
         MetronomeForegroundService.setBeatListener(beatIndex -> {
+            PluginCall call = savedBeatCall;
+            if (call == null) {
+                return;
+            }
             JSObject payload = new JSObject();
             payload.put("beatIndex", beatIndex);
-            notifyListeners("beat", payload);
+            call.resolve(payload);
         });
     }
 
     @Override
     protected void handleOnDestroy() {
         MetronomeForegroundService.clearBeatListener();
+        if (savedBeatCall != null) {
+            bridge.releaseCall(savedBeatCall);
+            savedBeatCall = null;
+        }
         super.handleOnDestroy();
+    }
+
+    @PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)
+    public void addBeatListener(PluginCall call) {
+        if (savedBeatCall != null) {
+            bridge.releaseCall(savedBeatCall);
+        }
+        call.setKeepAlive(true);
+        savedBeatCall = call;
+    }
+
+    @PluginMethod
+    public void removeBeatListener(PluginCall call) {
+        if (savedBeatCall != null) {
+            bridge.releaseCall(savedBeatCall);
+            savedBeatCall = null;
+        }
+        call.resolve();
     }
 
     @PluginMethod

--- a/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
+++ b/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeBackgroundPlugin.java
@@ -15,6 +15,22 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "MetronomeBackground")
 public class MetronomeBackgroundPlugin extends Plugin {
 
+    @Override
+    public void load() {
+        super.load();
+        MetronomeForegroundService.setBeatListener(beatIndex -> {
+            JSObject payload = new JSObject();
+            payload.put("beatIndex", beatIndex);
+            notifyListeners("beat", payload);
+        });
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        MetronomeForegroundService.clearBeatListener();
+        super.handleOnDestroy();
+    }
+
     @PluginMethod
     public void initialize(PluginCall call) {
         JSObject result = new JSObject();

--- a/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeForegroundService.java
+++ b/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeForegroundService.java
@@ -20,40 +20,43 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class MetronomeForegroundService extends Service {
-    public static final String ACTION_START = "com.zhengyaoliu.metrognome.background.action.START";
-    public static final String ACTION_UPDATE = "com.zhengyaoliu.metrognome.background.action.UPDATE";
-    public static final String ACTION_STOP = "com.zhengyaoliu.metrognome.background.action.STOP";
+    // --- Beat listener bridge -----------------------------------------------
+    // The plugin owns the listener instance (set in load(), cleared in
+    // handleOnDestroy()), so a strong static reference is correct here -
+    // the plugin's lifecycle keeps it alive, and clearBeatListener() drops
+    // it when the activity tears down.
 
     public interface BeatListener {
         void onBeat(int beatIndex);
     }
 
-    private static final AtomicReference<WeakReference<BeatListener>> beatListenerRef = new AtomicReference<>(null);
+    private static volatile BeatListener beatListener;
 
     public static void setBeatListener(BeatListener listener) {
-        beatListenerRef.set(listener == null ? null : new WeakReference<>(listener));
+        beatListener = listener;
     }
 
     public static void clearBeatListener() {
-        beatListenerRef.set(null);
+        beatListener = null;
     }
 
     private static void notifyBeat(int beatIndex) {
-        WeakReference<BeatListener> ref = beatListenerRef.get();
-        if (ref == null) {
-            return;
-        }
-        BeatListener listener = ref.get();
+        BeatListener listener = beatListener;
         if (listener != null) {
             listener.onBeat(beatIndex);
         }
     }
+
+    // --- Service intent contract -------------------------------------------
+
+    public static final String ACTION_START = "com.zhengyaoliu.metrognome.background.action.START";
+    public static final String ACTION_UPDATE = "com.zhengyaoliu.metrognome.background.action.UPDATE";
+    public static final String ACTION_STOP = "com.zhengyaoliu.metrognome.background.action.STOP";
 
     public static final String EXTRA_BPM = "bpm";
     public static final String EXTRA_BEATS = "beats";

--- a/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeForegroundService.java
+++ b/plugins/capacitor-metronome-background/android/src/main/java/com/zhengyaoliu/metrognome/background/MetronomeForegroundService.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,6 +29,31 @@ public class MetronomeForegroundService extends Service {
     public static final String ACTION_START = "com.zhengyaoliu.metrognome.background.action.START";
     public static final String ACTION_UPDATE = "com.zhengyaoliu.metrognome.background.action.UPDATE";
     public static final String ACTION_STOP = "com.zhengyaoliu.metrognome.background.action.STOP";
+
+    public interface BeatListener {
+        void onBeat(int beatIndex);
+    }
+
+    private static final AtomicReference<WeakReference<BeatListener>> beatListenerRef = new AtomicReference<>(null);
+
+    public static void setBeatListener(BeatListener listener) {
+        beatListenerRef.set(listener == null ? null : new WeakReference<>(listener));
+    }
+
+    public static void clearBeatListener() {
+        beatListenerRef.set(null);
+    }
+
+    private static void notifyBeat(int beatIndex) {
+        WeakReference<BeatListener> ref = beatListenerRef.get();
+        if (ref == null) {
+            return;
+        }
+        BeatListener listener = ref.get();
+        if (listener != null) {
+            listener.onBeat(beatIndex);
+        }
+    }
 
     public static final String EXTRA_BPM = "bpm";
     public static final String EXTRA_BEATS = "beats";
@@ -240,6 +266,12 @@ public class MetronomeForegroundService extends Service {
                     int offset = (int) (startFrame - blockStart);
                     if (cfg.subdivision[noteIdx] == 1) {
                         voices.add(new Voice(pickClick(cfg, beatIdx, noteIdx), offset));
+                    }
+                    // Beat boundary: fire on the first sub-note of each beat,
+                    // unconditional (matches web Player.step which emits beat
+                    // regardless of subdivision[0] being muted).
+                    if (noteIdx == 0) {
+                        notifyBeat(beatIdx);
                     }
                     noteIdx++;
                     if (noteIdx >= cfg.subdivision.length) {

--- a/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeAudioEngine.swift
+++ b/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeAudioEngine.swift
@@ -36,6 +36,11 @@ final class MetronomeAudioEngine {
     private let engine = AVAudioEngine()
     private var sourceNode: AVAudioSourceNode!
 
+    /// Called from the realtime render thread on every beat boundary
+    /// (first sub-note of a beat). Callers must trampoline to a safe
+    /// queue before doing any non-realtime-safe work.
+    var onBeat: ((Int) -> Void)?
+
     // Mutated only by main/plugin thread (under `lock`).
     private var lock = os_unfair_lock_s()
     private var pending: Config? = nil
@@ -182,6 +187,12 @@ final class MetronomeAudioEngine {
             let offset = Int(Int64(startFrame) - blockStart)
             if noteIdx < current.subdivision.count, current.subdivision[noteIdx] == 1 {
                 voices.append(Voice(data: pickClick(), pos: 0, offset: offset))
+            }
+            // Beat boundary: fire on the first sub-note of each beat,
+            // unconditional (matches web Player.step which emits beat
+            // regardless of whether subdivision[0] is muted).
+            if noteIdx == 0 {
+                onBeat?(beatIdx)
             }
             noteIdx += 1
             if noteIdx >= subLen {

--- a/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
+++ b/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
@@ -15,6 +15,15 @@ public class MetronomeBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private let engine = MetronomeAudioEngine()
 
+    override public func load() {
+        super.load()
+        engine.onBeat = { [weak self] beatIndex in
+            DispatchQueue.main.async {
+                self?.notifyListeners("beat", data: ["beatIndex": beatIndex])
+            }
+        }
+    }
+
     @objc func initialize(_ call: CAPPluginCall) {
         call.resolve(["available": true])
     }

--- a/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
+++ b/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
@@ -11,6 +11,10 @@ public class MetronomeBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "startPlayback", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "updatePlayback", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "stopPlayback", returnType: CAPPluginReturnPromise),
+        // CAPBridgedPlugin requires every JS-callable method to be enumerated
+        // here, including the inherited listener machinery from CAPPlugin.
+        CAPPluginMethod(name: "addListener", returnType: CAPPluginReturnCallback),
+        CAPPluginMethod(name: "removeAllListeners", returnType: CAPPluginReturnNone),
     ]
 
     private let engine = MetronomeAudioEngine()

--- a/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
+++ b/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
@@ -11,21 +11,36 @@ public class MetronomeBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "startPlayback", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "updatePlayback", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "stopPlayback", returnType: CAPPluginReturnPromise),
-        // CAPBridgedPlugin requires every JS-callable method to be enumerated
-        // here, including the inherited listener machinery from CAPPlugin.
-        CAPPluginMethod(name: "addListener", returnType: CAPPluginReturnCallback),
-        CAPPluginMethod(name: "removeAllListeners", returnType: CAPPluginReturnNone),
+        CAPPluginMethod(name: "addBeatListener", returnType: CAPPluginReturnCallback),
+        CAPPluginMethod(name: "removeBeatListener", returnType: CAPPluginReturnPromise),
     ]
 
     private let engine = MetronomeAudioEngine()
+    private var savedBeatCall: CAPPluginCall?
 
     override public func load() {
         super.load()
         engine.onBeat = { [weak self] beatIndex in
             DispatchQueue.main.async {
-                self?.notifyListeners("beat", data: ["beatIndex": beatIndex])
+                self?.savedBeatCall?.resolve(["beatIndex": beatIndex])
             }
         }
+    }
+
+    @objc func addBeatListener(_ call: CAPPluginCall) {
+        if let previous = savedBeatCall {
+            bridge?.releaseCall(previous)
+        }
+        call.keepAlive = true
+        savedBeatCall = call
+    }
+
+    @objc func removeBeatListener(_ call: CAPPluginCall) {
+        if let previous = savedBeatCall {
+            bridge?.releaseCall(previous)
+            savedBeatCall = nil
+        }
+        call.resolve()
     }
 
     @objc func initialize(_ call: CAPPluginCall) {

--- a/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
+++ b/plugins/capacitor-metronome-background/ios/Sources/MetronomeBackgroundPlugin/MetronomeBackgroundPlugin.swift
@@ -37,27 +37,11 @@ public class MetronomeBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func startPlayback(_ call: CAPPluginCall) {
-        do {
-            let config = try parseConfig(call: call)
-            try engine.start(config: config)
-            call.resolve()
-        } catch let error as ConfigError {
-            call.reject(error.message)
-        } catch {
-            call.reject("Failed to start native metronome playback: \(error.localizedDescription)")
-        }
+        runWithConfig(call, operationLabel: "start") { try engine.start(config: $0) }
     }
 
     @objc func updatePlayback(_ call: CAPPluginCall) {
-        do {
-            let config = try parseConfig(call: call)
-            engine.update(config: config)
-            call.resolve()
-        } catch let error as ConfigError {
-            call.reject(error.message)
-        } catch {
-            call.reject("Failed to update native metronome playback: \(error.localizedDescription)")
-        }
+        runWithConfig(call, operationLabel: "update") { engine.update(config: $0) }
     }
 
     @objc func stopPlayback(_ call: CAPPluginCall) {
@@ -68,6 +52,22 @@ public class MetronomeBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
     // MARK: - Helpers
 
     private struct ConfigError: Error { let message: String }
+
+    private func runWithConfig(
+        _ call: CAPPluginCall,
+        operationLabel: String,
+        action: (MetronomeAudioEngine.Config) throws -> Void
+    ) {
+        do {
+            let config = try parseConfig(call: call)
+            try action(config)
+            call.resolve()
+        } catch let error as ConfigError {
+            call.reject(error.message)
+        } catch {
+            call.reject("Failed to \(operationLabel) native metronome playback: \(error.localizedDescription)")
+        }
+    }
 
     private func parseConfig(call: CAPPluginCall) throws -> MetronomeAudioEngine.Config {
         let bpm = call.getInt("bpm") ?? 60

--- a/plugins/capacitor-metronome-background/src/definitions.ts
+++ b/plugins/capacitor-metronome-background/src/definitions.ts
@@ -17,11 +17,10 @@ export interface MetronomeBeatEvent {
 /**
  * Curated public surface for the native metronome background plugin.
  *
- * The native code emits `notifyListeners("beat", ...)` on every beat
- * boundary; rather than expose Capacitor's generic `addListener` overload
- * and force callers to know the wire event name, this interface presents
- * a named `addBeatListener` instead. The underlying bridge subscription is
- * an implementation detail of the wrapper in `index.ts`.
+ * The plugin exposes a single domain event (one beat per beat boundary)
+ * through `addBeatListener`. Subscribing returns a `PluginListenerHandle`
+ * whose `remove()` tears down the native callback - no generic listener
+ * API leaks to consumers.
  */
 export interface MetronomeBackgroundPlugin {
     initialize(): Promise<{ available: boolean }>;
@@ -30,5 +29,4 @@ export interface MetronomeBackgroundPlugin {
     updatePlayback(options: MetronomeBackgroundUpdateOptions): Promise<void>;
     stopPlayback(): Promise<void>;
     addBeatListener(listener: (event: MetronomeBeatEvent) => void): Promise<PluginListenerHandle>;
-    removeAllListeners(): Promise<void>;
 }

--- a/plugins/capacitor-metronome-background/src/definitions.ts
+++ b/plugins/capacitor-metronome-background/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 export interface MetronomeBackgroundStartOptions {
     bpm: number;
     beats: number;
@@ -8,10 +10,19 @@ export interface MetronomeBackgroundStartOptions {
 
 export type MetronomeBackgroundUpdateOptions = MetronomeBackgroundStartOptions;
 
+export interface MetronomeBeatEvent {
+    beatIndex: number;
+}
+
 export interface MetronomeBackgroundPlugin {
     initialize(): Promise<{ available: boolean }>;
     isAvailable(): Promise<{ available: boolean }>;
     startPlayback(options: MetronomeBackgroundStartOptions): Promise<void>;
     updatePlayback(options: MetronomeBackgroundUpdateOptions): Promise<void>;
     stopPlayback(): Promise<void>;
+    addListener(
+        eventName: 'beat',
+        listener: (event: MetronomeBeatEvent) => void
+    ): Promise<PluginListenerHandle> & PluginListenerHandle;
+    removeAllListeners(): Promise<void>;
 }

--- a/plugins/capacitor-metronome-background/src/definitions.ts
+++ b/plugins/capacitor-metronome-background/src/definitions.ts
@@ -14,15 +14,21 @@ export interface MetronomeBeatEvent {
     beatIndex: number;
 }
 
+/**
+ * Curated public surface for the native metronome background plugin.
+ *
+ * The native code emits `notifyListeners("beat", ...)` on every beat
+ * boundary; rather than expose Capacitor's generic `addListener` overload
+ * and force callers to know the wire event name, this interface presents
+ * a named `addBeatListener` instead. The underlying bridge subscription is
+ * an implementation detail of the wrapper in `index.ts`.
+ */
 export interface MetronomeBackgroundPlugin {
     initialize(): Promise<{ available: boolean }>;
     isAvailable(): Promise<{ available: boolean }>;
     startPlayback(options: MetronomeBackgroundStartOptions): Promise<void>;
     updatePlayback(options: MetronomeBackgroundUpdateOptions): Promise<void>;
     stopPlayback(): Promise<void>;
-    addListener(
-        eventName: 'beat',
-        listener: (event: MetronomeBeatEvent) => void
-    ): Promise<PluginListenerHandle> & PluginListenerHandle;
+    addBeatListener(listener: (event: MetronomeBeatEvent) => void): Promise<PluginListenerHandle>;
     removeAllListeners(): Promise<void>;
 }

--- a/plugins/capacitor-metronome-background/src/index.ts
+++ b/plugins/capacitor-metronome-background/src/index.ts
@@ -9,9 +9,10 @@ import type {
 } from './definitions';
 
 /**
- * Raw bridge surface exposed by Capacitor's registerPlugin. Kept module-
- * private so callers go through the curated MetronomeBackground facade
- * below and don't need to know the wire event name 'beat'.
+ * Raw bridge surface exposed by Capacitor's registerPlugin. The native
+ * plugins implement addBeatListener as a kept-alive callback method and
+ * pair it with removeBeatListener for teardown - we wrap the two-step
+ * pattern into a PluginListenerHandle in the facade below.
  */
 interface NativePlugin {
     initialize(): Promise<{ available: boolean }>;
@@ -19,11 +20,8 @@ interface NativePlugin {
     startPlayback(options: MetronomeBackgroundStartOptions): Promise<void>;
     updatePlayback(options: MetronomeBackgroundUpdateOptions): Promise<void>;
     stopPlayback(): Promise<void>;
-    addListener(
-        eventName: 'beat',
-        listener: (event: MetronomeBeatEvent) => void
-    ): Promise<PluginListenerHandle> & PluginListenerHandle;
-    removeAllListeners(): Promise<void>;
+    addBeatListener(listener: (event: MetronomeBeatEvent) => void): Promise<string>;
+    removeBeatListener(options: { callbackId: string }): Promise<void>;
 }
 
 const native = registerPlugin<NativePlugin>('MetronomeBackground');
@@ -34,8 +32,14 @@ export const MetronomeBackground: MetronomeBackgroundPlugin = {
     startPlayback: (options) => native.startPlayback(options),
     updatePlayback: (options) => native.updatePlayback(options),
     stopPlayback: () => native.stopPlayback(),
-    addBeatListener: (listener) => native.addListener('beat', listener),
-    removeAllListeners: () => native.removeAllListeners(),
+    addBeatListener: async (listener): Promise<PluginListenerHandle> => {
+        const callbackId = await native.addBeatListener(listener);
+        return {
+            remove: async () => {
+                await native.removeBeatListener({ callbackId });
+            },
+        };
+    },
 };
 
 export * from './definitions';

--- a/plugins/capacitor-metronome-background/src/index.ts
+++ b/plugins/capacitor-metronome-background/src/index.ts
@@ -1,8 +1,41 @@
 import { registerPlugin } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 
-import type { MetronomeBackgroundPlugin } from './definitions';
+import type {
+    MetronomeBackgroundPlugin,
+    MetronomeBackgroundStartOptions,
+    MetronomeBackgroundUpdateOptions,
+    MetronomeBeatEvent,
+} from './definitions';
 
-const MetronomeBackground = registerPlugin<MetronomeBackgroundPlugin>('MetronomeBackground');
+/**
+ * Raw bridge surface exposed by Capacitor's registerPlugin. Kept module-
+ * private so callers go through the curated MetronomeBackground facade
+ * below and don't need to know the wire event name 'beat'.
+ */
+interface NativePlugin {
+    initialize(): Promise<{ available: boolean }>;
+    isAvailable(): Promise<{ available: boolean }>;
+    startPlayback(options: MetronomeBackgroundStartOptions): Promise<void>;
+    updatePlayback(options: MetronomeBackgroundUpdateOptions): Promise<void>;
+    stopPlayback(): Promise<void>;
+    addListener(
+        eventName: 'beat',
+        listener: (event: MetronomeBeatEvent) => void
+    ): Promise<PluginListenerHandle> & PluginListenerHandle;
+    removeAllListeners(): Promise<void>;
+}
+
+const native = registerPlugin<NativePlugin>('MetronomeBackground');
+
+export const MetronomeBackground: MetronomeBackgroundPlugin = {
+    initialize: () => native.initialize(),
+    isAvailable: () => native.isAvailable(),
+    startPlayback: (options) => native.startPlayback(options),
+    updatePlayback: (options) => native.updatePlayback(options),
+    stopPlayback: () => native.stopPlayback(),
+    addBeatListener: (listener) => native.addListener('beat', listener),
+    removeAllListeners: () => native.removeAllListeners(),
+};
 
 export * from './definitions';
-export { MetronomeBackground };

--- a/src/scripts/extensions/event.ts
+++ b/src/scripts/extensions/event.ts
@@ -26,7 +26,7 @@ type Events = {
     play: void;
     stop: void;
 
-    beat: void;
+    beat: BeatEvent;
 
     switch: Mode;
     tap: void;
@@ -44,6 +44,10 @@ export type ChangeBeatsEvent = {
 
 export type PlayEvent = {
     replay: boolean;
+};
+
+export type BeatEvent = {
+    beatIndex: number;
 };
 
 export type Mode = 'play' | 'tap';

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -16,6 +16,7 @@ import SubdivisionModule from '~/modules/subdivision';
 import { App } from '~/extensions/module';
 import type { Module } from '~/extensions/module';
 import { Speaker } from '~/extensions/speaker';
+import { configurePlaybackEngines } from '~/platform/native';
 import { SupportedPlatform, PLATFORM_ELEMENT_IDS } from '~/platform/config';
 import { getElementByIdOrThrow } from '~/extensions/dom';
 
@@ -56,9 +57,10 @@ function displayBadge(platform: string): void {
 
 function launch(): App {
     const speaker = new Speaker();
+    configurePlaybackEngines(speaker);
     return new Metrognome()
         .load(new LanguageManager())
-        .load(new Player(speaker))
+        .load(new Player())
         .load(new TapModule(speaker))
         .load(new DotModule())
         .load(new BpmModule())

--- a/src/scripts/modules/dot.ts
+++ b/src/scripts/modules/dot.ts
@@ -1,10 +1,10 @@
-import bus from '~/extensions/event';
+import bus, { BeatEvent } from '~/extensions/event';
 import { Module } from '~/extensions/module';
 
 class DotModule extends Module {
     private dotList: HTMLUListElement = undefined!;
     private beats: number = 0;
-    private currentBeat: number = 0;
+    private currentBeat: number = -1;
 
     mount(): void {
         this.dotList = document.getElementById('dot-list') as HTMLUListElement;
@@ -17,21 +17,37 @@ class DotModule extends Module {
 
     private onBeatsChanged(beats: number): void {
         this.beats = beats;
-        this.currentBeat = 0;
+        this.currentBeat = -1;
 
         this.initializeDots();
     }
 
     private onPlay(): void {
+        this.clearActive();
         this.currentBeat = -1;
     }
 
     private onStop(): void {
-        this.dotList.children[this.currentBeat].classList.remove('active');
+        this.clearActive();
     }
 
-    private onBeat(): void {
-        this.step();
+    private onBeat(event: BeatEvent): void {
+        this.clearActive();
+        this.currentBeat = event.beatIndex;
+        const dot = this.dotList.children[this.currentBeat];
+        if (dot) {
+            dot.classList.add('active');
+        }
+    }
+
+    private clearActive(): void {
+        if (this.currentBeat < 0) {
+            return;
+        }
+        const dot = this.dotList.children[this.currentBeat];
+        if (dot) {
+            dot.classList.remove('active');
+        }
     }
 
     private initializeDots(): void {
@@ -41,14 +57,6 @@ class DotModule extends Module {
             dot.classList.add('dot', 'grey-green-grad');
             this.dotList.appendChild(dot);
         }
-    }
-
-    private step(): void {
-        if (this.currentBeat != -1) {
-            this.dotList.children[this.currentBeat].classList.remove('active');
-        }
-        this.currentBeat = (this.currentBeat + 1) % this.beats;
-        this.dotList.children[this.currentBeat].classList.add('active');
     }
 }
 

--- a/src/scripts/modules/player.ts
+++ b/src/scripts/modules/player.ts
@@ -2,18 +2,8 @@ import type { PluginListenerHandle } from '@capacitor/core';
 
 import { Module } from '~/extensions/module';
 import bus, { PlayEvent } from '~/extensions/event';
-import { Speaker, Waveform } from '~/extensions/speaker';
-import {
-    addNativeBeatListener,
-    canUseNativePlayback,
-    startNativePlayback,
-    stopNativePlayback,
-    updateNativePlayback,
-} from '~/platform/native';
-
-const TICK_FREQ = 1600;
-const TOK_FREQ = 800;
-const TAK_FREQ = 600;
+import { Waveform } from '~/extensions/speaker';
+import { PlaybackEngine, PlaybackOptions, selectPlaybackEngine } from '~/platform/native';
 
 /**
  * {
@@ -25,30 +15,19 @@ const TAK_FREQ = 600;
  * }
  */
 class Player extends Module {
-    private speaker: Speaker;
-
     private bpm: number = 60;
     private beats: number = 4;
     private stressFirst: boolean = true;
     private subdivision: number[] = [1];
     private currentWaveform: Waveform = 'square';
 
-    private playbackBackend: 'web' | 'native' = 'web';
     private playing: boolean = false;
-
-    private intervalHandle: number = -1;
-    private currentBeat: number = 0;
-    private currentNote: number = 0;
-    private nativeBeatHandle: PluginListenerHandle | null = null;
+    private engine: PlaybackEngine | null = null;
+    private beatHandle: PluginListenerHandle | null = null;
 
     private playButton: HTMLButtonElement = undefined!;
     private playText: HTMLSpanElement = undefined!;
     private stopText: HTMLSpanElement = undefined!;
-
-    constructor(speaker: Speaker) {
-        super();
-        this.speaker = speaker;
-    }
 
     mount(): void {
         this.playButton = document.getElementById('play') as HTMLButtonElement;
@@ -69,63 +48,28 @@ class Player extends Module {
 
     private onBpmChanged(bpm: number): void {
         this.bpm = bpm;
-        if (!this.isPlaying()) {
-            return;
-        }
-        if (this.playbackBackend === 'native') {
-            void this.updateNativePlayback();
-        } else {
-            bus.emit('toggle-play', { replay: true });
-        }
+        this.pushUpdate();
     }
 
     private onBeatsChanged(beats: number): void {
         this.beats = beats;
-        if (!this.isPlaying()) {
-            return;
-        }
-        if (this.playbackBackend === 'native') {
-            void this.updateNativePlayback();
-            // Native engine resets beatIdx=0 on structural change; reset the
-            // visual dot so it stays blank until the next native beat event.
-            bus.emit('play');
-        } else {
-            bus.emit('toggle-play', { replay: true });
-        }
+        this.pushUpdate({ structural: true });
     }
 
     private onStressChanged(stress: boolean): void {
         this.stressFirst = stress;
-
-        if (this.isPlaying() && this.playbackBackend === 'native') {
-            void this.updateNativePlayback();
-        }
+        this.pushUpdate();
     }
 
     private onSubdivisionChanged(subdivision: number[]): void {
-        const lengthChanged = subdivision.length !== this.subdivision.length;
+        const structural = subdivision.length !== this.subdivision.length;
         this.subdivision = subdivision;
-        if (!this.isPlaying()) {
-            return;
-        }
-        if (this.playbackBackend === 'native') {
-            void this.updateNativePlayback();
-            if (lengthChanged) {
-                // Structural change on the native side resets beatIdx=0.
-                bus.emit('play');
-            }
-        } else {
-            bus.emit('toggle-play', { replay: true });
-        }
+        this.pushUpdate({ structural });
     }
 
     private onWaveformChanged(waveform: Waveform): void {
         this.currentWaveform = waveform;
-        this.speaker.setWaveform(waveform);
-
-        if (this.isPlaying() && this.playbackBackend === 'native') {
-            void this.updateNativePlayback();
-        }
+        this.pushUpdate();
     }
 
     private onTogglePlay(event: PlayEvent): void {
@@ -152,79 +96,79 @@ class Player extends Module {
         }
     }
 
-    private play(): void {
-        // play event should be emitted before beat event
-        bus.emit('play');
-
-        this.currentBeat = 0;
-        this.currentNote = 0;
-        this.playing = true;
-
-        this.selectPlaybackBackend();
-        if (this.playbackBackend === 'native') {
-            void this.startNativeFlow();
-        } else {
-            this.startWebTicker();
-        }
-    }
-
     private isPlaying(): boolean {
         return this.playing;
     }
 
-    private step(): void {
-        if (this.subdivision[this.currentNote] === 1) {
-            if (this.playbackBackend === 'web') {
-                if (this.isFirstBeat()) {
-                    this.speaker.play(this.stressFirst ? TICK_FREQ : TOK_FREQ);
-                } else {
-                    this.speaker.play(this.isFirstNote() ? TOK_FREQ : TAK_FREQ);
-                }
-            }
-        }
-
-        if (this.isFirstNote()) {
-            bus.emit('beat', { beatIndex: this.currentBeat });
-        }
-
-        if (++this.currentNote >= this.subdivision.length) {
-            this.currentNote = 0;
-            if (++this.currentBeat >= this.beats) {
-                this.currentBeat = 0;
-            }
-        }
+    private play(): void {
+        // play event must precede any beat event so DotModule clears first.
+        bus.emit('play');
+        this.playing = true;
+        this.engine = selectPlaybackEngine();
+        void this.startEngine();
     }
 
-    private isFirstBeat(): boolean {
-        return this.currentBeat === 0 && this.currentNote === 0;
-    }
+    private async startEngine(): Promise<void> {
+        const engine = this.engine;
+        if (!engine) {
+            return;
+        }
 
-    private isFirstNote(): boolean {
-        return this.currentNote === 0;
+        // Register the listener first to avoid missing the first beat event
+        // in the round-trip window before start() resolves.
+        this.beatHandle = await engine.addBeatListener((beatIndex) => {
+            if (this.playing && this.engine === engine) {
+                bus.emit('beat', { beatIndex });
+            }
+        });
+
+        if (!this.playing || this.engine !== engine) {
+            await this.beatHandle?.remove();
+            this.beatHandle = null;
+            return;
+        }
+
+        const started = await engine.start(this.buildOptions());
+
+        if (!this.playing || this.engine !== engine) {
+            await this.beatHandle?.remove();
+            this.beatHandle = null;
+            if (started) {
+                await engine.stop();
+            }
+        }
     }
 
     private stop(): void {
         this.playing = false;
+        const engine = this.engine;
+        const handle = this.beatHandle;
+        this.engine = null;
+        this.beatHandle = null;
 
-        if (this.playbackBackend === 'native') {
-            void stopNativePlayback();
-            if (this.nativeBeatHandle) {
-                void this.nativeBeatHandle.remove();
-                this.nativeBeatHandle = null;
-            }
+        if (handle) {
+            void handle.remove();
+        }
+        if (engine) {
+            void engine.stop();
         }
 
-        this.stopWebTicker();
-
         bus.emit('stop');
-        this.playbackBackend = 'web';
     }
 
-    private selectPlaybackBackend(): void {
-        this.playbackBackend = canUseNativePlayback() ? 'native' : 'web';
+    private pushUpdate(opts: { structural?: boolean } = {}): void {
+        if (!this.playing || !this.engine) {
+            return;
+        }
+        if (opts.structural) {
+            // Engines reset to beat 0 on structural changes; clear the dot
+            // so it stays blank until the next beat event arrives.
+            bus.emit('play');
+        }
+        void this.engine.update(this.buildOptions());
     }
 
-    private buildNativePlaybackOptions() {
+    private buildOptions(): PlaybackOptions {
         return {
             bpm: this.bpm,
             beats: this.beats,
@@ -232,70 +176,6 @@ class Player extends Module {
             subdivision: this.subdivision,
             waveform: this.currentWaveform,
         };
-    }
-
-    private async startNativeFlow(): Promise<void> {
-        // Register the JS listener before starting native playback so the
-        // first beat event isn't missed in the round-trip window.
-        this.nativeBeatHandle = await addNativeBeatListener((beatIndex) => {
-            if (this.playing && this.playbackBackend === 'native') {
-                bus.emit('beat', { beatIndex });
-            }
-        });
-
-        if (!this.playing) {
-            // Stopped before native start was issued.
-            await this.nativeBeatHandle?.remove();
-            this.nativeBeatHandle = null;
-            return;
-        }
-
-        const started = await startNativePlayback(this.buildNativePlaybackOptions());
-
-        if (!this.playing) {
-            // Stopped during the start round-trip; tear down whatever happened.
-            await this.nativeBeatHandle?.remove();
-            this.nativeBeatHandle = null;
-            if (started) {
-                await stopNativePlayback();
-            }
-            return;
-        }
-
-        if (!started) {
-            // Native failed to start; fall back to the JS ticker.
-            await this.nativeBeatHandle?.remove();
-            this.nativeBeatHandle = null;
-            this.playbackBackend = 'web';
-            this.startWebTicker();
-        }
-    }
-
-    private async updateNativePlayback(): Promise<void> {
-        const updated = await updateNativePlayback(this.buildNativePlaybackOptions());
-        if (!updated && this.playing) {
-            // Native update failed; fall back to the JS ticker.
-            if (this.nativeBeatHandle) {
-                await this.nativeBeatHandle.remove();
-                this.nativeBeatHandle = null;
-            }
-            this.playbackBackend = 'web';
-            this.startWebTicker();
-        }
-    }
-
-    private startWebTicker(): void {
-        this.stopWebTicker();
-        const delay = 60000.0 / (this.bpm * this.subdivision.length);
-        this.step();
-        this.intervalHandle = setInterval(() => this.step(), delay);
-    }
-
-    private stopWebTicker(): void {
-        if (this.intervalHandle !== -1) {
-            clearInterval(this.intervalHandle);
-            this.intervalHandle = -1;
-        }
     }
 
     private updateDisplay(): void {

--- a/src/scripts/modules/player.ts
+++ b/src/scripts/modules/player.ts
@@ -175,7 +175,7 @@ class Player extends Module {
         }
 
         if (this.isFirstNote()) {
-            bus.emit('beat');
+            bus.emit('beat', { beatIndex: this.currentBeat });
         }
 
         if (++this.currentNote >= this.subdivision.length) {

--- a/src/scripts/modules/player.ts
+++ b/src/scripts/modules/player.ts
@@ -1,7 +1,15 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 import { Module } from '~/extensions/module';
 import bus, { PlayEvent } from '~/extensions/event';
 import { Speaker, Waveform } from '~/extensions/speaker';
-import { canUseNativePlayback, startNativePlayback, stopNativePlayback, updateNativePlayback } from '~/platform/native';
+import {
+    addNativeBeatListener,
+    canUseNativePlayback,
+    startNativePlayback,
+    stopNativePlayback,
+    updateNativePlayback,
+} from '~/platform/native';
 
 const TICK_FREQ = 1600;
 const TOK_FREQ = 800;
@@ -26,10 +34,12 @@ class Player extends Module {
     private currentWaveform: Waveform = 'square';
 
     private playbackBackend: 'web' | 'native' = 'web';
+    private playing: boolean = false;
 
     private intervalHandle: number = -1;
     private currentBeat: number = 0;
     private currentNote: number = 0;
+    private nativeBeatHandle: PluginListenerHandle | null = null;
 
     private playButton: HTMLButtonElement = undefined!;
     private playText: HTMLSpanElement = undefined!;
@@ -64,7 +74,6 @@ class Player extends Module {
         }
         if (this.playbackBackend === 'native') {
             void this.updateNativePlayback();
-            this.restartTickerOnly();
         } else {
             bus.emit('toggle-play', { replay: true });
         }
@@ -77,7 +86,9 @@ class Player extends Module {
         }
         if (this.playbackBackend === 'native') {
             void this.updateNativePlayback();
-            this.resyncNativeFromBeatZero();
+            // Native engine resets beatIdx=0 on structural change; reset the
+            // visual dot so it stays blank until the next native beat event.
+            bus.emit('play');
         } else {
             bus.emit('toggle-play', { replay: true });
         }
@@ -100,9 +111,8 @@ class Player extends Module {
         if (this.playbackBackend === 'native') {
             void this.updateNativePlayback();
             if (lengthChanged) {
-                this.resyncNativeFromBeatZero();
-            } else {
-                this.restartTickerOnly();
+                // Structural change on the native side resets beatIdx=0.
+                bus.emit('play');
             }
         } else {
             bus.emit('toggle-play', { replay: true });
@@ -146,21 +156,20 @@ class Player extends Module {
         // play event should be emitted before beat event
         bus.emit('play');
 
-        const delay = 60000.0 / (this.bpm * this.subdivision.length);
         this.currentBeat = 0;
         this.currentNote = 0;
+        this.playing = true;
 
         this.selectPlaybackBackend();
         if (this.playbackBackend === 'native') {
-            void this.startNativePlayback();
+            void this.startNativeFlow();
+        } else {
+            this.startWebTicker();
         }
-
-        this.step();
-        this.intervalHandle = setInterval(() => this.step(), delay);
     }
 
     private isPlaying(): boolean {
-        return this.intervalHandle !== -1;
+        return this.playing;
     }
 
     private step(): void {
@@ -195,16 +204,19 @@ class Player extends Module {
     }
 
     private stop(): void {
+        this.playing = false;
+
         if (this.playbackBackend === 'native') {
             void stopNativePlayback();
+            if (this.nativeBeatHandle) {
+                void this.nativeBeatHandle.remove();
+                this.nativeBeatHandle = null;
+            }
         }
 
-        if (this.intervalHandle !== -1) {
-            clearInterval(this.intervalHandle);
-            this.intervalHandle = -1;
-            bus.emit('stop');
-        }
+        this.stopWebTicker();
 
+        bus.emit('stop');
         this.playbackBackend = 'web';
     }
 
@@ -222,37 +234,68 @@ class Player extends Module {
         };
     }
 
-    private async startNativePlayback(): Promise<void> {
+    private async startNativeFlow(): Promise<void> {
+        // Register the JS listener before starting native playback so the
+        // first beat event isn't missed in the round-trip window.
+        this.nativeBeatHandle = await addNativeBeatListener((beatIndex) => {
+            if (this.playing && this.playbackBackend === 'native') {
+                bus.emit('beat', { beatIndex });
+            }
+        });
+
+        if (!this.playing) {
+            // Stopped before native start was issued.
+            await this.nativeBeatHandle?.remove();
+            this.nativeBeatHandle = null;
+            return;
+        }
+
         const started = await startNativePlayback(this.buildNativePlaybackOptions());
+
+        if (!this.playing) {
+            // Stopped during the start round-trip; tear down whatever happened.
+            await this.nativeBeatHandle?.remove();
+            this.nativeBeatHandle = null;
+            if (started) {
+                await stopNativePlayback();
+            }
+            return;
+        }
+
         if (!started) {
+            // Native failed to start; fall back to the JS ticker.
+            await this.nativeBeatHandle?.remove();
+            this.nativeBeatHandle = null;
             this.playbackBackend = 'web';
+            this.startWebTicker();
         }
     }
 
     private async updateNativePlayback(): Promise<void> {
         const updated = await updateNativePlayback(this.buildNativePlaybackOptions());
-        if (!updated) {
+        if (!updated && this.playing) {
+            // Native update failed; fall back to the JS ticker.
+            if (this.nativeBeatHandle) {
+                await this.nativeBeatHandle.remove();
+                this.nativeBeatHandle = null;
+            }
             this.playbackBackend = 'web';
+            this.startWebTicker();
         }
     }
 
-    private restartTickerOnly(): void {
-        if (this.intervalHandle !== -1) {
-            clearInterval(this.intervalHandle);
-        }
+    private startWebTicker(): void {
+        this.stopWebTicker();
         const delay = 60000.0 / (this.bpm * this.subdivision.length);
+        this.step();
         this.intervalHandle = setInterval(() => this.step(), delay);
     }
 
-    private resyncNativeFromBeatZero(): void {
-        // Native side resets to beat 0; reset JS visual state and fire the
-        // first step immediately so the dot highlights in sync with the
-        // upcoming native click instead of waiting a full beat period.
-        this.currentBeat = 0;
-        this.currentNote = 0;
-        bus.emit('play');
-        this.step();
-        this.restartTickerOnly();
+    private stopWebTicker(): void {
+        if (this.intervalHandle !== -1) {
+            clearInterval(this.intervalHandle);
+            this.intervalHandle = -1;
+        }
     }
 
     private updateDisplay(): void {

--- a/src/scripts/platform/android-native.ts
+++ b/src/scripts/platform/android-native.ts
@@ -87,7 +87,7 @@ async function addAndroidBeatListener(
     }
 
     try {
-        return await MetronomeBackground.addListener('beat', (event) => handler(event.beatIndex));
+        return await MetronomeBackground.addBeatListener((event) => handler(event.beatIndex));
     } catch (error) {
         console.warn('[android-native] Failed to add beat listener', error);
         return null;

--- a/src/scripts/platform/android-native.ts
+++ b/src/scripts/platform/android-native.ts
@@ -31,11 +31,11 @@ export async function initializeAndroidNativePlayback(): Promise<void> {
     }
 }
 
-export function canUseAndroidNativePlayback(): boolean {
+function canUseAndroidNativePlayback(): boolean {
     return isAndroidPlatform() && nativeReady;
 }
 
-export async function startAndroidNativePlayback(options: MetronomeBackgroundStartOptions): Promise<boolean> {
+async function startAndroidNativePlayback(options: MetronomeBackgroundStartOptions): Promise<boolean> {
     if (!canUseAndroidNativePlayback()) {
         return false;
     }
@@ -50,7 +50,7 @@ export async function startAndroidNativePlayback(options: MetronomeBackgroundSta
     }
 }
 
-export async function updateAndroidNativePlayback(options: MetronomeBackgroundUpdateOptions): Promise<boolean> {
+async function updateAndroidNativePlayback(options: MetronomeBackgroundUpdateOptions): Promise<boolean> {
     if (!canUseAndroidNativePlayback()) {
         return false;
     }
@@ -65,7 +65,7 @@ export async function updateAndroidNativePlayback(options: MetronomeBackgroundUp
     }
 }
 
-export async function stopAndroidNativePlayback(): Promise<boolean> {
+async function stopAndroidNativePlayback(): Promise<boolean> {
     if (!isAndroidPlatform()) {
         return false;
     }
@@ -79,7 +79,7 @@ export async function stopAndroidNativePlayback(): Promise<boolean> {
     }
 }
 
-export async function addAndroidBeatListener(
+async function addAndroidBeatListener(
     handler: (beatIndex: number) => void
 ): Promise<PluginListenerHandle | null> {
     if (!canUseAndroidNativePlayback()) {

--- a/src/scripts/platform/android-native.ts
+++ b/src/scripts/platform/android-native.ts
@@ -1,4 +1,5 @@
 import { Capacitor } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 import {
     MetronomeBackground,
     MetronomeBackgroundStartOptions,
@@ -73,5 +74,20 @@ export async function stopAndroidNativePlayback(): Promise<boolean> {
     } catch (error) {
         console.warn('[android-native] Failed to stop native playback', error);
         return false;
+    }
+}
+
+export async function addAndroidBeatListener(
+    handler: (beatIndex: number) => void
+): Promise<PluginListenerHandle | null> {
+    if (!canUseAndroidNativePlayback()) {
+        return null;
+    }
+
+    try {
+        return await MetronomeBackground.addListener('beat', (event) => handler(event.beatIndex));
+    } catch (error) {
+        console.warn('[android-native] Failed to add beat listener', error);
+        return null;
     }
 }

--- a/src/scripts/platform/android-native.ts
+++ b/src/scripts/platform/android-native.ts
@@ -6,6 +6,8 @@ import {
     MetronomeBackgroundUpdateOptions,
 } from 'capacitor-metronome-background';
 
+import type { PlaybackEngine, PlaybackOptions } from '~/platform/native';
+
 let initialized = false;
 let nativeReady = false;
 
@@ -91,3 +93,11 @@ export async function addAndroidBeatListener(
         return null;
     }
 }
+
+export const androidPlaybackEngine: PlaybackEngine = {
+    canUse: canUseAndroidNativePlayback,
+    start: (options: PlaybackOptions) => startAndroidNativePlayback(options),
+    update: (options: PlaybackOptions) => updateAndroidNativePlayback(options),
+    stop: stopAndroidNativePlayback,
+    addBeatListener: addAndroidBeatListener,
+};

--- a/src/scripts/platform/ios-native.ts
+++ b/src/scripts/platform/ios-native.ts
@@ -87,7 +87,7 @@ async function addIosBeatListener(
     }
 
     try {
-        return await MetronomeBackground.addListener('beat', (event) => handler(event.beatIndex));
+        return await MetronomeBackground.addBeatListener((event) => handler(event.beatIndex));
     } catch (error) {
         console.warn('[ios-native] Failed to add beat listener', error);
         return null;

--- a/src/scripts/platform/ios-native.ts
+++ b/src/scripts/platform/ios-native.ts
@@ -31,11 +31,11 @@ export async function initializeIosNativePlayback(): Promise<void> {
     }
 }
 
-export function canUseIosNativePlayback(): boolean {
+function canUseIosNativePlayback(): boolean {
     return isIosPlatform() && nativeReady;
 }
 
-export async function startIosNativePlayback(options: MetronomeBackgroundStartOptions): Promise<boolean> {
+async function startIosNativePlayback(options: MetronomeBackgroundStartOptions): Promise<boolean> {
     if (!canUseIosNativePlayback()) {
         return false;
     }
@@ -50,7 +50,7 @@ export async function startIosNativePlayback(options: MetronomeBackgroundStartOp
     }
 }
 
-export async function updateIosNativePlayback(options: MetronomeBackgroundUpdateOptions): Promise<boolean> {
+async function updateIosNativePlayback(options: MetronomeBackgroundUpdateOptions): Promise<boolean> {
     if (!canUseIosNativePlayback()) {
         return false;
     }
@@ -65,7 +65,7 @@ export async function updateIosNativePlayback(options: MetronomeBackgroundUpdate
     }
 }
 
-export async function stopIosNativePlayback(): Promise<boolean> {
+async function stopIosNativePlayback(): Promise<boolean> {
     if (!isIosPlatform()) {
         return false;
     }
@@ -79,7 +79,7 @@ export async function stopIosNativePlayback(): Promise<boolean> {
     }
 }
 
-export async function addIosBeatListener(
+async function addIosBeatListener(
     handler: (beatIndex: number) => void
 ): Promise<PluginListenerHandle | null> {
     if (!canUseIosNativePlayback()) {

--- a/src/scripts/platform/ios-native.ts
+++ b/src/scripts/platform/ios-native.ts
@@ -6,6 +6,8 @@ import {
     MetronomeBackgroundUpdateOptions,
 } from 'capacitor-metronome-background';
 
+import type { PlaybackEngine, PlaybackOptions } from '~/platform/native';
+
 let initialized = false;
 let nativeReady = false;
 
@@ -91,3 +93,11 @@ export async function addIosBeatListener(
         return null;
     }
 }
+
+export const iosPlaybackEngine: PlaybackEngine = {
+    canUse: canUseIosNativePlayback,
+    start: (options: PlaybackOptions) => startIosNativePlayback(options),
+    update: (options: PlaybackOptions) => updateIosNativePlayback(options),
+    stop: stopIosNativePlayback,
+    addBeatListener: addIosBeatListener,
+};

--- a/src/scripts/platform/ios-native.ts
+++ b/src/scripts/platform/ios-native.ts
@@ -1,4 +1,5 @@
 import { Capacitor } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 import {
     MetronomeBackground,
     MetronomeBackgroundStartOptions,
@@ -73,5 +74,20 @@ export async function stopIosNativePlayback(): Promise<boolean> {
     } catch (error) {
         console.warn('[ios-native] Failed to stop native playback', error);
         return false;
+    }
+}
+
+export async function addIosBeatListener(
+    handler: (beatIndex: number) => void
+): Promise<PluginListenerHandle | null> {
+    if (!canUseIosNativePlayback()) {
+        return null;
+    }
+
+    try {
+        return await MetronomeBackground.addListener('beat', (event) => handler(event.beatIndex));
+    } catch (error) {
+        console.warn('[ios-native] Failed to add beat listener', error);
+        return null;
     }
 }

--- a/src/scripts/platform/native.ts
+++ b/src/scripts/platform/native.ts
@@ -1,23 +1,9 @@
 import type { PluginListenerHandle } from '@capacitor/core';
-import type { MetronomeBackgroundStartOptions, MetronomeBackgroundUpdateOptions } from 'capacitor-metronome-background';
+import type { MetronomeBackgroundStartOptions } from 'capacitor-metronome-background';
 
 import { Speaker } from '~/extensions/speaker';
-import {
-    addAndroidBeatListener,
-    androidPlaybackEngine,
-    canUseAndroidNativePlayback,
-    startAndroidNativePlayback,
-    stopAndroidNativePlayback,
-    updateAndroidNativePlayback,
-} from '~/platform/android-native';
-import {
-    addIosBeatListener,
-    canUseIosNativePlayback,
-    iosPlaybackEngine,
-    startIosNativePlayback,
-    stopIosNativePlayback,
-    updateIosNativePlayback,
-} from '~/platform/ios-native';
+import { androidPlaybackEngine } from '~/platform/android-native';
+import { iosPlaybackEngine } from '~/platform/ios-native';
 import { createWebPlaybackEngine } from '~/platform/web-native';
 
 export type PlaybackOptions = MetronomeBackgroundStartOptions;
@@ -60,47 +46,4 @@ export function selectPlaybackEngine(): PlaybackEngine {
         throw new Error('Web playback engine not configured; call configurePlaybackEngines() first.');
     }
     return webEngine;
-}
-
-// --- legacy free-function facade (still used by Player; removed in the next commit) ---
-
-export function canUseNativePlayback(): boolean {
-    return canUseAndroidNativePlayback() || canUseIosNativePlayback();
-}
-
-export async function startNativePlayback(options: MetronomeBackgroundStartOptions): Promise<boolean> {
-    if (canUseAndroidNativePlayback()) {
-        return startAndroidNativePlayback(options);
-    }
-    if (canUseIosNativePlayback()) {
-        return startIosNativePlayback(options);
-    }
-    return false;
-}
-
-export async function updateNativePlayback(options: MetronomeBackgroundUpdateOptions): Promise<boolean> {
-    if (canUseAndroidNativePlayback()) {
-        return updateAndroidNativePlayback(options);
-    }
-    if (canUseIosNativePlayback()) {
-        return updateIosNativePlayback(options);
-    }
-    return false;
-}
-
-export async function stopNativePlayback(): Promise<boolean> {
-    const results = await Promise.all([stopAndroidNativePlayback(), stopIosNativePlayback()]);
-    return results.some((ok) => ok);
-}
-
-export async function addNativeBeatListener(
-    handler: (beatIndex: number) => void
-): Promise<PluginListenerHandle | null> {
-    if (canUseAndroidNativePlayback()) {
-        return addAndroidBeatListener(handler);
-    }
-    if (canUseIosNativePlayback()) {
-        return addIosBeatListener(handler);
-    }
-    return null;
 }

--- a/src/scripts/platform/native.ts
+++ b/src/scripts/platform/native.ts
@@ -1,10 +1,13 @@
+import type { PluginListenerHandle } from '@capacitor/core';
 import {
+    addAndroidBeatListener,
     canUseAndroidNativePlayback,
     startAndroidNativePlayback,
     stopAndroidNativePlayback,
     updateAndroidNativePlayback,
 } from '~/platform/android-native';
 import {
+    addIosBeatListener,
     canUseIosNativePlayback,
     startIosNativePlayback,
     stopIosNativePlayback,
@@ -46,4 +49,16 @@ export async function stopNativePlayback(): Promise<boolean> {
     // Stop both - whichever was active will succeed; the other no-ops.
     const results = await Promise.all([stopAndroidNativePlayback(), stopIosNativePlayback()]);
     return results.some((ok) => ok);
+}
+
+export async function addNativeBeatListener(
+    handler: (beatIndex: number) => void
+): Promise<PluginListenerHandle | null> {
+    if (canUseAndroidNativePlayback()) {
+        return addAndroidBeatListener(handler);
+    }
+    if (canUseIosNativePlayback()) {
+        return addIosBeatListener(handler);
+    }
+    return null;
 }

--- a/src/scripts/platform/native.ts
+++ b/src/scripts/platform/native.ts
@@ -1,6 +1,10 @@
 import type { PluginListenerHandle } from '@capacitor/core';
+import type { MetronomeBackgroundStartOptions, MetronomeBackgroundUpdateOptions } from 'capacitor-metronome-background';
+
+import { Speaker } from '~/extensions/speaker';
 import {
     addAndroidBeatListener,
+    androidPlaybackEngine,
     canUseAndroidNativePlayback,
     startAndroidNativePlayback,
     stopAndroidNativePlayback,
@@ -9,18 +13,57 @@ import {
 import {
     addIosBeatListener,
     canUseIosNativePlayback,
+    iosPlaybackEngine,
     startIosNativePlayback,
     stopIosNativePlayback,
     updateIosNativePlayback,
 } from '~/platform/ios-native';
-import type { MetronomeBackgroundStartOptions, MetronomeBackgroundUpdateOptions } from 'capacitor-metronome-background';
+import { createWebPlaybackEngine } from '~/platform/web-native';
+
+export type PlaybackOptions = MetronomeBackgroundStartOptions;
 
 /**
- * Unified facade over the per-platform native playback backends.
- * Player code stays platform-agnostic: it asks for availability, then
- * delegates start/update/stop. Each call returns false on failure so the
- * caller can transparently fall back to the Web Audio backend.
+ * Unified contract every platform-specific playback backend implements.
+ * The Player drives this interface without knowing whether it's talking to
+ * the web Audio API, the Android foreground service, or the iOS audio engine.
  */
+export interface PlaybackEngine {
+    canUse(): boolean;
+    start(options: PlaybackOptions): Promise<boolean>;
+    update(options: PlaybackOptions): Promise<boolean>;
+    stop(): Promise<boolean>;
+    addBeatListener(handler: (beatIndex: number) => void): Promise<PluginListenerHandle | null>;
+}
+
+let webEngine: PlaybackEngine | null = null;
+
+/**
+ * Bind the shared Speaker into the web playback engine. Must be called once
+ * during app startup, before any `selectPlaybackEngine()` consumer plays.
+ */
+export function configurePlaybackEngines(speaker: Speaker): void {
+    webEngine = createWebPlaybackEngine(speaker);
+}
+
+/**
+ * Return the first available engine in platform-preference order:
+ * Android → iOS → web (universal fallback).
+ */
+export function selectPlaybackEngine(): PlaybackEngine {
+    if (androidPlaybackEngine.canUse()) {
+        return androidPlaybackEngine;
+    }
+    if (iosPlaybackEngine.canUse()) {
+        return iosPlaybackEngine;
+    }
+    if (!webEngine) {
+        throw new Error('Web playback engine not configured; call configurePlaybackEngines() first.');
+    }
+    return webEngine;
+}
+
+// --- legacy free-function facade (still used by Player; removed in the next commit) ---
+
 export function canUseNativePlayback(): boolean {
     return canUseAndroidNativePlayback() || canUseIosNativePlayback();
 }
@@ -46,7 +89,6 @@ export async function updateNativePlayback(options: MetronomeBackgroundUpdateOpt
 }
 
 export async function stopNativePlayback(): Promise<boolean> {
-    // Stop both - whichever was active will succeed; the other no-ops.
     const results = await Promise.all([stopAndroidNativePlayback(), stopIosNativePlayback()]);
     return results.some((ok) => ok);
 }

--- a/src/scripts/platform/web-native.ts
+++ b/src/scripts/platform/web-native.ts
@@ -1,0 +1,143 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
+import { Speaker, Waveform } from '~/extensions/speaker';
+import type { PlaybackEngine, PlaybackOptions } from '~/platform/native';
+
+const TICK_FREQ = 1600;
+const TOK_FREQ = 800;
+const TAK_FREQ = 600;
+
+type Listener = (beatIndex: number) => void;
+
+/**
+ * Web Audio playback engine. Mirrors the interface of the Android and iOS
+ * native engines so the Player can stay backend-agnostic. The audio clock
+ * here is a JS setInterval, so audio and beat-event are driven from the same
+ * callback - no cross-clock drift on web.
+ */
+class WebPlaybackEngine implements PlaybackEngine {
+    private speaker: Speaker;
+
+    private bpm: number = 60;
+    private beats: number = 4;
+    private stressFirst: boolean = true;
+    private subdivision: number[] = [1];
+    private waveform: Waveform = 'square';
+
+    private running: boolean = false;
+    private currentBeat: number = 0;
+    private currentNote: number = 0;
+    private intervalHandle: number = -1;
+    private listeners: Set<Listener> = new Set();
+
+    constructor(speaker: Speaker) {
+        this.speaker = speaker;
+    }
+
+    canUse(): boolean {
+        return true;
+    }
+
+    async start(options: PlaybackOptions): Promise<boolean> {
+        this.applyOptions(options);
+        this.running = true;
+        this.currentBeat = 0;
+        this.currentNote = 0;
+        this.tick();
+        this.scheduleTicker();
+        return true;
+    }
+
+    async update(options: PlaybackOptions): Promise<boolean> {
+        const structural =
+            this.running &&
+            (options.beats !== this.beats || options.subdivision.length !== this.subdivision.length);
+        this.applyOptions(options);
+        if (!this.running) {
+            return true;
+        }
+        if (structural) {
+            this.currentBeat = 0;
+            this.currentNote = 0;
+            this.clearTicker();
+            this.tick();
+            this.scheduleTicker();
+        } else {
+            this.clearTicker();
+            this.scheduleTicker();
+        }
+        return true;
+    }
+
+    async stop(): Promise<boolean> {
+        this.running = false;
+        this.clearTicker();
+        return true;
+    }
+
+    async addBeatListener(handler: Listener): Promise<PluginListenerHandle | null> {
+        this.listeners.add(handler);
+        const remove = async () => {
+            this.listeners.delete(handler);
+        };
+        return { remove };
+    }
+
+    private applyOptions(options: PlaybackOptions): void {
+        this.bpm = options.bpm;
+        this.beats = options.beats;
+        this.stressFirst = options.stressFirst;
+        this.subdivision = options.subdivision.length > 0 ? options.subdivision : [1];
+        const requested = options.waveform as Waveform | undefined;
+        if (requested) {
+            this.waveform = requested;
+        }
+        this.speaker.setWaveform(this.waveform);
+    }
+
+    private scheduleTicker(): void {
+        const delay = 60000.0 / (this.bpm * this.subdivision.length);
+        this.intervalHandle = setInterval(() => this.tick(), delay);
+    }
+
+    private clearTicker(): void {
+        if (this.intervalHandle !== -1) {
+            clearInterval(this.intervalHandle);
+            this.intervalHandle = -1;
+        }
+    }
+
+    private tick(): void {
+        if (this.subdivision[this.currentNote] === 1) {
+            if (this.isFirstBeat()) {
+                this.speaker.play(this.stressFirst ? TICK_FREQ : TOK_FREQ);
+            } else {
+                this.speaker.play(this.isFirstNote() ? TOK_FREQ : TAK_FREQ);
+            }
+        }
+
+        if (this.isFirstNote()) {
+            const beatIndex = this.currentBeat;
+            this.listeners.forEach((listener) => listener(beatIndex));
+        }
+
+        if (++this.currentNote >= this.subdivision.length) {
+            this.currentNote = 0;
+            if (++this.currentBeat >= this.beats) {
+                this.currentBeat = 0;
+            }
+        }
+    }
+
+    private isFirstBeat(): boolean {
+        return this.currentBeat === 0 && this.currentNote === 0;
+    }
+
+    private isFirstNote(): boolean {
+        return this.currentNote === 0;
+    }
+}
+
+export function createWebPlaybackEngine(speaker: Speaker): PlaybackEngine {
+    return new WebPlaybackEngine(speaker);
+}


### PR DESCRIPTION
Lock the visual beat to the native audio clock and unify playback behind a single engine interface.

## Changes

- Add a `beat` event to the Capacitor plugin TS interface.
- Fire a beat callback from the Android audio loop and the iOS audio engine on every beat boundary.
- Carry `{ beatIndex }` on the bus `'beat'` event so the dot applies the authoritative index directly.
- Introduce a `PlaybackEngine` interface and add `web-native.ts` alongside `android-native.ts` and `ios-native.ts`.
- Refactor `Player` to drive any backend through the engine; remove the `'web' | 'native'` branching and the JS `setInterval` from Player.
- On web, preserve the current beat position on non-structural config changes (matches native engines).

## Fixes

- Drift between the visual beat and native audio over time on iOS and Android.
- Dot misalignment after mid-play resyncs such as changing the beats count.
